### PR TITLE
Change to official latest Java 7 docker hub image

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM       dockerfile/java:oracle-java7
+FROM       java:7
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 ENV SONATYPE_WORK /sonatype-work
@@ -29,4 +29,3 @@ CMD java \
   -cp 'conf/:lib/*' \
   ${JAVA_OPTS} \
   org.sonatype.nexus.bootstrap.Launcher ./conf/jetty.xml ./conf/jetty-requestlog.xml
-

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -1,4 +1,4 @@
-FROM       dockerfile/java:oracle-java7
+FROM       java:7
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 ENV SONATYPE_WORK /sonatype-work
@@ -29,4 +29,3 @@ CMD java \
   -cp 'conf/:lib/*' \
   ${JAVA_OPTS} \
   org.sonatype.nexus.bootstrap.Launcher ./conf/jetty.xml ./conf/jetty-requestlog.xml
-


### PR DESCRIPTION
Your Docker Hub build is KO because (I think) your Java docker image doesn't exist.

See the following screenshot : 

![capture du 2015-05-23 12 48 58](https://cloud.githubusercontent.com/assets/1193670/7783678/28dd5658-014a-11e5-9b5e-9d5e9a8e1373.png)