### PR TITLE
curl Download url fix

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -2,7 +2,7 @@ FROM       centos:centos7
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 ENV SONATYPE_WORK /sonatype-work
-ENV NEXUS_VERSION 3.0.0-b2015110601
+ENV NEXUS_VERSION 2.11.4-01
 
 RUN yum install -y \
   curl tar createrepo \

--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -2,7 +2,7 @@ FROM       centos:centos7
 MAINTAINER Sonatype <cloud-ops@sonatype.com>
 
 ENV SONATYPE_WORK /sonatype-work
-ENV NEXUS_VERSION 2.11.4-01
+ENV NEXUS_VERSION 3.0.0-b2015110601
 
 RUN yum install -y \
   curl tar createrepo \
@@ -17,7 +17,7 @@ RUN cd /var/tmp \
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \
-    https://download.sonatype.com/nexus/oss/nexus-${NEXUS_VERSION}-bundle.tar.gz \
+    https://sonatype-download.global.ssl.fastly.net/nexus/oss/nexus-${NEXUS_VERSION}-bundle.tar.gz \
   | gunzip \
   | tar x -C /tmp nexus-${NEXUS_VERSION} \
   && mv /tmp/nexus-${NEXUS_VERSION}/* /opt/sonatype/nexus/ \


### PR DESCRIPTION
There is a change on curl URL for nexus download:

This is nos working anymore

https://download.sonatype.com/nexus/oss/nexus-2.11.4-01-bundle.tar.gz 

This is working

https://sonatype-download.global.ssl.fastly.net/nexus/oss/nexus-2.11.4-01-bundle.tar.gz