### PR TITLE
added docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+  nexus:
+    image: sonatype/nexus
+    volumes:
+      - "nexus-data:/sonatype-work"
+    ports:
+      - "8081:8081"
+  
+volumes:
+  nexus-data: {}
+


### PR DESCRIPTION
Hi guys, I added a compose file for use with docker-compose 1.6 .

Nexus can now be started with:
```
$ docker-compose up
Starting dockernexus_nexus_1
...

$ docker-compose ps
       Name                      Command               State           Ports          
-------------------------------------------------------------------------------------
dockernexus_nexus_1   /bin/sh -c java   -Dnexus- ...   Up      0.0.0.0:8081->8081/tcp
```

Persistent data is stored in a volume container "nexus-data"

```
$ docker volume ls
DRIVER              VOLUME NAME
local               dockernexus_nexus-data

$ docker volume inspect dockernexus_nexus-data 
[
    {
        "Name": "dockernexus_nexus-data",
        "Driver": "local",
        "Mountpoint": "/var/lib/docker/volumes/dockernexus_nexus-data/_data"
    }
]

$ sudo ls -1 /var/lib/docker/volumes/dockernexus_nexus-data/_data/
backup
conf
db
felix-cache
health-check
indexer
logs
nexus.lock
nuget
plugin-repository
storage
timeline
```