### PR TITLE
Fix error in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ additional information.
 
   ```
   $ mkdir /some/dir/nexus-data && chown -R 200 /some/dir/nexus-data
-  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/sonatype-work sonatype/nexus
+  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus
   ```
 
 


### PR DESCRIPTION
I believe the correct directory to mount the volume should be `/nexus-data` instead of `/sonatype-work`.

Thanks!