### PR TITLE
change default CONTEXT_ROOT to /nexus

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -37,7 +37,7 @@ VOLUME ${SONATYPE_WORK}
 EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
-ENV CONTEXT_PATH /
+ENV CONTEXT_PATH /nexus
 ENV MAX_HEAP 768m
 ENV MIN_HEAP 256m
 ENV JAVA_OPTS -server -Djava.net.preferIPv4Stack=true

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -37,7 +37,7 @@ VOLUME ${SONATYPE_WORK}
 EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
-ENV CONTEXT_PATH /
+ENV CONTEXT_PATH /nexus
 ENV MAX_HEAP 768m
 ENV MIN_HEAP 256m
 ENV JAVA_OPTS -server -Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
This PR sets docker `ENV CONTEXT_PATH /nexus` in order to establish consistent behavior with how `/opt/sonatype/nexus/conf/nexus.properties` would normally spin up nexus. While the user can set this variable herself, it's not expected that she would need to do this. The README indicates that this variable exists, but not that it needs to be set to establish this consistency. Additionally, this PR will help ensure URI's are consistent with the documentation and common examples on the WWW.