### PR TITLE
fix status URL in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To determine the port that the container is listening on:
 To test:
 
 ```
-$ curl http://localhost:8081/nexus/service/local/status
+$ curl http://localhost:8081/service/local/status
 ```
 
 To build, copy the Dockerfile and do the build:


### PR DESCRIPTION
tested with OSS:

the status url does not contain nexus in its path.