### PR TITLE
Revert "EXPOSE keyword in Dockerfile is deprecated. (#24)"

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -34,6 +34,7 @@ RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/fal
 
 VOLUME ${SONATYPE_WORK}
 
+EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
 ENV CONTEXT_PATH /nexus

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -34,6 +34,7 @@ RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/fal
 
 VOLUME ${SONATYPE_WORK}
 
+EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
 ENV CONTEXT_PATH /nexus


### PR DESCRIPTION
Hello! In #24 the EXPOSE step was removed from the Dockerfiles.  However, I don't think the use of EXPOSE 'port' was deprecated. Rather, EXPOSE 'port:port' has been deprecated ([indication](https://github.com/SvenDowideit/docker/blob/2275c83358986c9f612ebb1915c5d3392319f1f8/runtime.go#L351-L362))

Testing these changes, it doesn't look like this affects the running process.  However, it helps orchestration tools like OpenShift run this image properly.

If there is something I'm missing, please let me know!