### PR TITLE
re-added EXPOSE directive

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -34,6 +34,7 @@ RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/fal
 
 VOLUME ${SONATYPE_WORK}
 
+EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
 ENV CONTEXT_PATH /nexus

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -34,6 +34,7 @@ RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/fal
 
 VOLUME ${SONATYPE_WORK}
 
+EXPOSE 8081
 WORKDIR /opt/sonatype/nexus
 USER nexus
 ENV CONTEXT_PATH /nexus


### PR DESCRIPTION
This change (https://github.com/sonatype/docker-nexus/pull/24) removed the EXPOSE 8081 directive. The change mentions that EXPOSE is deprecated, but this isn't true. Actually 'The mapping to public ports on your host via Dockerfile EXPOSE (host:port:port) has been deprecated. Use -p to publish the ports.' (https://github.com/SvenDowideit/docker/commit/2275c83358986c9f612ebb1915c5d3392319f1f8).

Also see https://docs.docker.com/engine/reference/builder/#/expose. 

"The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. EXPOSE does not make the ports of the container accessible to the host."

I use orchestration tooling that uses the ports defined using the EXPOSE directive.

EXPOSE 8081 doesn't actually do anything. It only records which port(s) might be of interest.