### PR TITLE
Checking java download against a checksum for security

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -25,19 +25,21 @@ ENV JAVA_HOME /opt/java
 ENV JAVA_VERSION_MAJOR 8
 ENV JAVA_VERSION_MINOR 102
 ENV JAVA_VERSION_BUILD 14
-             
+ENV JAVA_CHECKSUM="50bc7ff61ba064c471adc2ec08e44690f0dac4cd673a3666b6d7b24a48bd7169"
+
 RUN yum install -y \
   curl tar createrepo \
   && yum clean all
 
 # install Oracle JRE
 RUN mkdir -p /opt \
-  && curl --fail --silent --location --retry 3 \
+  && curl --fail --silent --location --retry 3 --output server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz \
   --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
   http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz \
-  | gunzip \
-  | tar -x -C /opt \
-  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME}
+  && echo "${JAVA_CHECKSUM}  server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz" | sha256sum --quiet --strict --check - \
+  && tar -xzf server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz -C /opt \
+  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} \
+  && rm server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -25,6 +25,7 @@ ENV JAVA_HOME /opt/java
 ENV JAVA_VERSION_MAJOR 8
 ENV JAVA_VERSION_MINOR 102
 ENV JAVA_VERSION_BUILD 14
+ENV JAVA_CHECKSUM="50bc7ff61ba064c471adc2ec08e44690f0dac4cd673a3666b6d7b24a48bd7169"
 
 RUN yum install -y \
   curl tar createrepo \
@@ -32,12 +33,13 @@ RUN yum install -y \
 
 # install Oracle JRE
 RUN mkdir -p /opt \
-  && curl --fail --silent --location --retry 3 \
+  && curl --fail --silent --location --retry 3 --output server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz \
   --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
   http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz \
-  | gunzip \
-  | tar -x -C /opt \
-  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME}
+  && echo "${JAVA_CHECKSUM}  server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz" | sha256sum --quiet --strict --check - \
+  && tar -xzf server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz -C /opt \
+  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} \
+  && rm server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \


### PR DESCRIPTION
Since Oracle's JRE is being downloaded over HTTP, but not checked against a secure checksum, I considered this a bit of a security issue. I added a variable for a sha256 checksum and checked against this after the download in the OSS and Pro dockerfiles.

Oracle supplies these checksums officially for this version at https://www.oracle.com/webfolder/s/digest/8u102checksum.html

Subsequent updates of the JRE version in these dockerfiles should update the checksum accordingly.

Feel free to give me feedback if the change should need more work. :)