### PR TITLE
Nexus user nofile limits to 65536

### DIFF
--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -51,7 +51,8 @@ RUN mkdir -p /opt/sonatype/nexus \
   && mv /tmp/nexus-${NEXUS_VERSION}/* /opt/sonatype/nexus/ \
   && rm -rf /tmp/nexus-${NEXUS_VERSION}
 
-RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/false nexus
+RUN useradd -r -u 200 -m -c "nexus role account" -d ${SONATYPE_WORK} -s /bin/false nexus \
+    && echo 'nexus - nofile 65536' >> /etc/security/limits.conf
 
 VOLUME ${SONATYPE_WORK}
 


### PR DESCRIPTION
As required by Nexus itself in the doc (and WebUI popup) : https://help.sonatype.com/display/NXRM3/System+Requirements#filehandles