### PR TITLE
Switchover to OpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sonatype/docker-nexus
 
-Docker images for Sonatype Nexus Repository Manager 2 with the Oracle JDK.
+Docker images for Sonatype Nexus Repository Manager 2 with the OpenJDK.
 For Nexus Repository Manager 3, please refer to https://github.com/sonatype/docker-nexus3
 
 * [Notes](#notes)

--- a/oss/Dockerfile
+++ b/oss/Dockerfile
@@ -21,27 +21,10 @@ LABEL vendor=Sonatype \
 ARG NEXUS_VERSION=2.14.11-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/oss/nexus-${NEXUS_VERSION}-bundle.tar.gz
 
-ENV SONATYPE_WORK=/sonatype-work \
-    JAVA_HOME=/opt/java \
-    JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=192 \
-    JAVA_VERSION_BUILD=12 \
-    JAVA_DOWNLOAD_HASH=750e1c8617c5452694857ad95c3ee230
-
-ENV JAVA_URL=http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_DOWNLOAD_HASH}/server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz
-
+ENV SONATYPE_WORK=/sonatype-work
 RUN yum install -y \
-  curl tar createrepo \
+  curl tar createrepo java-1.8.0-openjdk \
   && yum clean all
-
-# install Oracle JRE
-RUN mkdir -p /opt \
-  && curl --fail --silent --location --retry 3 \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
-  ${JAVA_URL} \
-  | gunzip \
-  | tar -x -C /opt \
-  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME}
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \
@@ -63,7 +46,7 @@ ENV MAX_HEAP 768m
 ENV MIN_HEAP 256m
 ENV JAVA_OPTS -server -Djava.net.preferIPv4Stack=true
 ENV LAUNCHER_CONF ./conf/jetty.xml ./conf/jetty-requestlog.xml
-CMD ${JAVA_HOME}/bin/java \
+CMD java \
   -Dnexus-work=${SONATYPE_WORK} -Dnexus-webapp-context-path=${CONTEXT_PATH} \
   -Xms${MIN_HEAP} -Xmx${MAX_HEAP} \
   -cp 'conf/:lib/*' \

--- a/pro/Dockerfile
+++ b/pro/Dockerfile
@@ -21,27 +21,11 @@ LABEL vendor=Sonatype \
 ARG NEXUS_VERSION=2.14.11-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/professional-bundle/nexus-professional-${NEXUS_VERSION}-bundle.tar.gz
 
-ENV SONATYPE_WORK=/sonatype-work \
-    JAVA_HOME=/opt/java \
-    JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=192 \
-    JAVA_VERSION_BUILD=12 \
-    JAVA_DOWNLOAD_HASH=750e1c8617c5452694857ad95c3ee230
-
-ENV JAVA_URL=http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_DOWNLOAD_HASH}/server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz
+ENV SONATYPE_WORK=/sonatype-work
 
 RUN yum install -y \
-  curl tar createrepo \
+  curl tar createrepo java-1.8.0-openjdk \
   && yum clean all
-
-# install Oracle JRE
-RUN mkdir -p /opt \
-  && curl --fail --silent --location --retry 3 \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie; " \
-  ${JAVA_URL} \
-  | gunzip \
-  | tar -x -C /opt \
-  && ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME}
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \
@@ -63,7 +47,7 @@ ENV MAX_HEAP 768m
 ENV MIN_HEAP 256m
 ENV JAVA_OPTS -server -Djava.net.preferIPv4Stack=true
 ENV LAUNCHER_CONF ./conf/jetty.xml ./conf/jetty-requestlog.xml
-CMD ${JAVA_HOME}/bin/java \
+CMD java \
   -Dnexus-work=${SONATYPE_WORK} -Dnexus-webapp-context-path=${CONTEXT_PATH} \
   -Djava.util.prefs.userRoot=${SONATYPE_WORK}/javaprefs \
   -Xms${MIN_HEAP} -Xmx${MAX_HEAP} \


### PR DESCRIPTION
Switch from Oracle JDK to OpenJDK 8.

This pull request makes the following changes:
- Removes code related to Oracle JDK
- Uses OpenJDK 8 as dependency in Chef's recipe

It relates to the following issue #s:
- Resolves [NEXUS-18693](https://issues.sonatype.org/browse/NEXUS-18693)